### PR TITLE
Add DB class

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -1,6 +1,8 @@
 require('aws-sdk/clients/dynamodb')
 const AWS = require('aws-sdk/global')
 
+const timestamp = require('./timestamp')
+
 class DB {
   constructor (tableName, region = 'eu-west-2') {
     this.docClient = new AWS.DynamoDB.DocumentClient({ region })
@@ -22,7 +24,7 @@ class DB {
       Key
     }
 
-    const timeNow = Math.floor(Date.now() / 1000)
+    const timeNow = timestamp.inSeconds()
 
     return new Promise((resolve, reject) => {
       this.docClient.get(params, (err, data) => {

--- a/src/db.js
+++ b/src/db.js
@@ -4,7 +4,7 @@ const AWS = require('aws-sdk/global')
 const timestamp = require('./timestamp')
 
 class DB {
-  constructor (tableName, region = 'eu-west-2') {
+  constructor (tableName, region) {
     this.docClient = new AWS.DynamoDB.DocumentClient({ region })
     this.tableName = tableName
   }

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,88 @@
+const DynamoDB = require('aws-sdk/clients/dynamodb')
+const AWS = require('aws-sdk/global')
+
+class DB {
+  constructor (tableName, region = 'eu-west-2') {
+    this.docClient = new AWS.DynamoDB.DocumentClient({ region })
+    this.tableName = tableName
+  }
+
+  saveLoan (loanData) {
+    return this.save(loanData, this.loanCacheTable)
+  }
+
+  saveUser (userData) {
+    return this.save(userData, this.userCacheTable)
+  }
+
+  save (data) {
+    return new Promise((resolve, reject) => {
+      this.docClient.put({
+        Item: data,
+        TableName: this.tableName
+      }, (err, data) => {
+        err ? reject(err) : resolve(data)
+      })
+    })
+  }
+
+  getLoan (loan_id) {
+    const params = {
+      TableName: this.loanCacheTable,
+      Key: {
+        loan_id
+      }
+    }
+
+    return this.get(params)
+  }
+
+  get (Key) {
+    const params = {
+      TableName: this.tableName,
+      Key
+    }
+
+    const timeNow = Math.floor(Date.now() / 1000)
+
+    return new Promise((resolve, reject) => {
+      this.docClient.get(params, (err, data) => {
+        if (err) {
+          reject(err)
+        } else if (!data.Item) {
+          reject(new Error('No matching record found'))
+        } else if (data.Item.expiry_date && data.Item.expiry_date < timeNow) {
+          reject(new Error('No matching record found'))
+        } else {
+          resolve(data.Item)
+        }
+      })
+    })
+  }
+
+  deleteLoan (loan_id) {
+    const params = {
+      TableName: this.loanCacheTable,
+      Key: {
+        loan_id
+      }
+    }
+
+    return this.delete(params)
+  }
+
+  delete (Key) {
+    const params = {
+      TableName: this.tableName,
+      Key
+    }
+
+    return new Promise((resolve, reject) => {
+      this.docClient.delete(params, (err, data) => {
+        err ? reject(err) : resolve(data)
+      })
+    })
+  }
+}
+
+module.exports = DB

--- a/src/db.js
+++ b/src/db.js
@@ -45,11 +45,6 @@ class DB {
       Key
     }
 
-    // return new Promise((resolve, reject) => {
-    //   this.docClient.delete(params, (err, data) => {
-    //     err ? reject(err) : resolve(data)
-    //   })
-    // })
     return this.docClient.delete(params).promise()
   }
 }

--- a/src/db.js
+++ b/src/db.js
@@ -8,14 +8,12 @@ class DB {
   }
 
   save (data) {
-    return new Promise((resolve, reject) => {
-      this.docClient.put({
-        Item: data,
-        TableName: this.tableName
-      }, (err, data) => {
-        err ? reject(err) : resolve(data)
-      })
-    })
+    const params = {
+      Item: data,
+      TableName: this.tableName
+    }
+
+    return this.docClient.put(params).promise()
   }
 
   get (Key) {
@@ -47,11 +45,12 @@ class DB {
       Key
     }
 
-    return new Promise((resolve, reject) => {
-      this.docClient.delete(params, (err, data) => {
-        err ? reject(err) : resolve(data)
-      })
-    })
+    // return new Promise((resolve, reject) => {
+    //   this.docClient.delete(params, (err, data) => {
+    //     err ? reject(err) : resolve(data)
+    //   })
+    // })
+    return this.docClient.delete(params).promise()
   }
 }
 

--- a/src/db.js
+++ b/src/db.js
@@ -7,14 +7,6 @@ class DB {
     this.tableName = tableName
   }
 
-  saveLoan (loanData) {
-    return this.save(loanData, this.loanCacheTable)
-  }
-
-  saveUser (userData) {
-    return this.save(userData, this.userCacheTable)
-  }
-
   save (data) {
     return new Promise((resolve, reject) => {
       this.docClient.put({

--- a/src/db.js
+++ b/src/db.js
@@ -1,4 +1,4 @@
-const DynamoDB = require('aws-sdk/clients/dynamodb')
+require('aws-sdk/clients/dynamodb')
 const AWS = require('aws-sdk/global')
 
 class DB {
@@ -26,17 +26,6 @@ class DB {
     })
   }
 
-  getLoan (loan_id) {
-    const params = {
-      TableName: this.loanCacheTable,
-      Key: {
-        loan_id
-      }
-    }
-
-    return this.get(params)
-  }
-
   get (Key) {
     const params = {
       TableName: this.tableName,
@@ -58,17 +47,6 @@ class DB {
         }
       })
     })
-  }
-
-  deleteLoan (loan_id) {
-    const params = {
-      TableName: this.loanCacheTable,
-      Key: {
-        loan_id
-      }
-    }
-
-    return this.delete(params)
   }
 
   delete (Key) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 module.exports = {
-  Topic: require('./topic')
+  Topic: require('./topic'),
+  DB: require('./db')
 }

--- a/src/timestamp.js
+++ b/src/timestamp.js
@@ -1,0 +1,3 @@
+module.exports = {
+  inSeconds: () => Math.floor(Date.now() / 1000)
+}

--- a/test/db-test.js
+++ b/test/db-test.js
@@ -36,7 +36,7 @@ describe('db class tests', () => {
         TableName: 'UserCacheTable'
       }
 
-      const testDB = new DB('UserCacheTable')
+      const testDB = new DB('UserCacheTable', 'eu-west-2')
       return testDB.save({ user_id: 'a user' }).then(data => {
         putStub.should.be.calledWith(expected)
       })
@@ -47,7 +47,7 @@ describe('db class tests', () => {
       putStub.callsArgWith(1, new Error('DynamoDB put has failed'), null)
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'put', putStub)
 
-      const testDB = new DB('UserCacheTable')
+      const testDB = new DB('UserCacheTable', 'eu-west-2')
       return testDB.save({ user_id: 'a user' })
         .should.eventually.be.rejectedWith('DynamoDB put has failed')
         .should.eventually.be.an.instanceOf(Error)
@@ -77,7 +77,7 @@ describe('db class tests', () => {
         TableName: 'LoanCacheTable'
       }
 
-      let testDB = new DB('LoanCacheTable')
+      let testDB = new DB('LoanCacheTable', 'eu-west-2')
 
       return testDB.get({ loan_id: 'a loan' }).then(data => {
         getStub.should.be.calledWith(expected)
@@ -92,7 +92,7 @@ describe('db class tests', () => {
       }
 
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      let testDB = new DB('LoanCacheTable')
+      let testDB = new DB('LoanCacheTable', 'eu-west-2')
 
       return testDB.get({ loan_id: 'a loan' }).should.eventually.be.fulfilled
         .and.should.eventually.deep.equal({loan_id: 'a loan'})
@@ -107,7 +107,7 @@ describe('db class tests', () => {
       }
 
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      let testDB = new DB('LoanCacheTable')
+      let testDB = new DB('LoanCacheTable', 'eu-west-2')
 
       return testDB.get({ loan_id: 'a loan' }).should.eventually.be.rejectedWith('No matching record found')
         .and.should.eventually.be.an.instanceOf(Error)
@@ -122,7 +122,7 @@ describe('db class tests', () => {
       }
 
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      let testDB = new DB('LoanCacheTable')
+      let testDB = new DB('LoanCacheTable', 'eu-west-2')
 
       return testDB.get({ loan_id: 'a loan' }).should.eventually.be.fulfilled
         .and.should.eventually.deep.equal(getResult.Item)
@@ -132,7 +132,7 @@ describe('db class tests', () => {
       const getResult = {}
 
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      let testDB = new DB('LoanCacheTable')
+      let testDB = new DB('LoanCacheTable', 'eu-west-2')
 
       return testDB.get({ loan_id: 'a loan' }).should.eventually.be.rejectedWith('No matching record found')
         .and.should.eventually.be.an.instanceOf(Error)
@@ -143,7 +143,7 @@ describe('db class tests', () => {
       getStub.callsArgWith(1, new Error('DynamoDB broke'), null)
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getStub)
 
-      let testDB = new DB('LoanCacheTable')
+      let testDB = new DB('LoanCacheTable', 'eu-west-2')
 
       return testDB.get({ loan_id: 'a loan' }).should.eventually.be.rejectedWith('DynamoDB broke')
         .and.should.eventually.be.an.instanceOf(Error)
@@ -164,7 +164,7 @@ describe('db class tests', () => {
         loan_id: 'a loan'
       }
 
-      const testDB = new DB('a loan cache table')
+      const testDB = new DB('a loan cache table', 'eu-west-2')
 
       return testDB.delete(Key).then(() => {
         deleteStub.should.have.been.calledWith({
@@ -181,7 +181,7 @@ describe('db class tests', () => {
       deleteStub.callsArgWith(1, null, true)
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'delete', deleteStub)
 
-      const testDB = new DB()
+      const testDB = new DB('loanCacheTable', 'eu-west-2')
 
       return testDB.delete('success').should.eventually.be.fulfilled
     })
@@ -191,7 +191,7 @@ describe('db class tests', () => {
       deleteStub.callsArgWith(1, new Error('DynamoDB error'), null)
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'delete', deleteStub)
 
-      const testDB = new DB()
+      const testDB = new DB('loanCacheTable', 'eu-west-2')
 
       return testDB.delete('error').should.eventually.be.rejectedWith('DynamoDB error')
     })

--- a/test/db-test.js
+++ b/test/db-test.js
@@ -3,11 +3,11 @@ const sinon = require('sinon')
 
 // Test libraries
 const chai = require('chai')
-const chai_as_promised = require('chai-as-promised')
-chai.use(chai_as_promised)
-const sinon_chai = require('sinon-chai')
-chai.use(sinon_chai)
-const should = chai.should()
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const sinonChai = require('sinon-chai')
+chai.use(sinonChai)
+chai.should()
 
 const sandbox = sinon.sandbox.create()
 

--- a/test/db-test.js
+++ b/test/db-test.js
@@ -1,0 +1,341 @@
+const AWS_MOCK = require('aws-sdk-mock')
+const sinon = require('sinon')
+
+// Test libraries
+const chai = require('chai')
+const chai_as_promised = require('chai-as-promised')
+chai.use(chai_as_promised)
+const sinon_chai = require('sinon-chai')
+chai.use(sinon_chai)
+const should = chai.should()
+
+const sandbox = sinon.sandbox.create()
+
+// Module under test
+const DB = require('../src/db')
+
+describe('db class tests', () => {
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('save method', () => {
+    afterEach(() => {
+      AWS_MOCK.restore('DynamoDB.DocumentClient')
+    })
+
+    it('should call dynamodb with the input parameters', () => {
+      const putStub = sandbox.stub()
+      putStub.callsArgWith(1, null, true)
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'put', putStub)
+
+      const expected = {
+        Item: {
+          user_id: 'a user'
+        },
+        TableName: 'UserCacheTable'
+      }
+
+      const testDB = new DB()
+      return testDB.save({ user_id: 'a user' }, 'UserCacheTable').then(data => {
+        putStub.should.be.calledWith(expected)
+      })
+    })
+
+    it('should be rejected with an error if dynamodb fails', () => {
+      const putStub = sandbox.stub()
+      putStub.callsArgWith(1, new Error('DynamoDB put has failed'), null)
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'put', putStub)
+
+      const testDB = new DB()
+      return testDB.save({ user_id: 'a user' }, 'UserCacheTable')
+        .should.eventually.be.rejectedWith('DynamoDB put has failed')
+        .should.eventually.be.an.instanceOf(Error)
+    })
+  })
+
+  describe('save loan method', () => {
+    it('should call the save method with the input parameters and the loan cache table', () => {
+      const saveStub = sandbox.stub(DB.prototype, 'save')
+      saveStub.resolves(true)
+      const testDB = new DB({ loanCacheTable: 'loan cache table' })
+
+      return testDB.saveLoan('a loan').then(() => {
+        saveStub.should.have.been.calledWith('a loan', 'loan cache table')
+      })
+    })
+  })
+
+  describe('save user method', () => {
+    it('should call the save method with the input parameters and the user cache table', () => {
+      const saveStub = sandbox.stub(DB.prototype, 'save')
+      saveStub.resolves(true)
+      const testDB = new DB({ userCacheTable: 'user cache table' })
+
+      return testDB.saveUser('a user').then(() => {
+        saveStub.should.have.been.calledWith('a user', 'user cache table')
+      })
+    })
+  })
+
+  describe('get user method', () => {
+    afterEach(() => {
+      AWS_MOCK.restore('DynamoDB.DocumentClient')
+    })
+
+    it('should call dynamodb get with the correct parameters', () => {
+      const getStub = sinon.stub()
+
+      const getResult = {
+        Item: {
+          user_id: 'a user'
+        }
+      }
+      getStub.callsArgWith(1, null, getResult)
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getStub)
+
+      const expected = {
+        Key: {
+          user_id: 'a user'
+        },
+        TableName: 'UserCacheTable'
+      }
+
+      testDB = new DB({ userCacheTable: 'UserCacheTable' })
+
+      return testDB.getUser('a user').then(data => {
+        getStub.should.be.calledWith(expected)
+      })
+    })
+
+    it('should resolve with a user record if a matching user is found with no expiry date set', () => {
+      const getResult = {
+        Item: {
+          user_id: 'a user'
+        }
+      }
+
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
+      testDB = new DB({ userCacheTable: 'UserCacheTable' })
+
+      return testDB.getUser('a user').should.eventually.be.fulfilled
+        .and.should.eventually.deep.equal({user_id: 'a user'})
+    })
+
+    it('should reject with an error if the user\'s expiry date is in the past', () => {
+      const getResult = {
+        Item: {
+          user_id: 'a user',
+          expiry_date: Math.floor(Date.now() / 1000) - 10
+        }
+      }
+
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
+      testDB = new DB({ userCacheTable: 'UserCacheTable' })
+
+      return testDB.getUser('a user').should.eventually.be.rejectedWith('No matching record found')
+        .and.should.eventually.be.an.instanceOf(Error)
+    })
+
+    it('should resolve with a user record if the expiry date is in the future', () => {
+      const getResult = {
+        Item: {
+          user_id: 'a user',
+          expiry_date: Math.floor(Date.now() / 1000) + 10
+        }
+      }
+
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
+      testDB = new DB({ userCacheTable: 'UserCacheTable' })
+
+      return testDB.getUser('a user').should.eventually.be.fulfilled
+        .and.should.eventually.deep.equal(getResult.Item)
+    })
+
+    it('should be rejected with an error if no matching user record is found', () => {
+      const getResult = {}
+
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
+      testDB = new DB({ userCacheTable: 'UserCacheTable' })
+
+      return testDB.getUser('a user').should.eventually.be.rejectedWith('No matching record found')
+        .and.should.eventually.be.an.instanceOf(Error)
+    })
+
+    it('should be rejected with an error if dynamodb fails', () => {
+      const getStub = sinon.stub()
+      getStub.callsArgWith(1, new Error('DynamoDB broke'), null)
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getStub)
+
+      testDB = new DB({ userCacheTable: 'UserCacheTable' })
+
+      return testDB.getUser('a user').should.eventually.be.rejectedWith('DynamoDB broke')
+        .and.should.eventually.be.an.instanceOf(Error)
+    })
+  })
+
+  describe('get loan method tests', () => {
+    afterEach(() => {
+      AWS_MOCK.restore('DynamoDB.DocumentClient')
+    })
+
+    it('should call dynamodb get with the correct parameters', () => {
+      const getStub = sinon.stub()
+
+      const getResult = {
+        Item: {
+          loan_id: 'a loan'
+        }
+      }
+      getStub.callsArgWith(1, null, getResult)
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getStub)
+
+      const expected = {
+        Key: {
+          loan_id: 'a loan'
+        },
+        TableName: 'LoanCacheTable'
+      }
+
+      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+
+      return testDB.getLoan('a loan').then(data => {
+        getStub.should.be.calledWith(expected)
+      })
+    })
+
+    it('should resolve with a loan record if a matching loan is found with no expiry date set', () => {
+      const getResult = {
+        Item: {
+          loan_id: 'a loan'
+        }
+      }
+
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
+      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+
+      return testDB.getLoan('a loan').should.eventually.be.fulfilled
+        .and.should.eventually.deep.equal({loan_id: 'a loan'})
+    })
+
+    it('should reject with an error if the loan\'s expiry date is in the past', () => {
+      const getResult = {
+        Item: {
+          loan_id: 'a loan',
+          expiry_date: Math.floor(Date.now() / 1000) - 10
+        }
+      }
+
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
+      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+
+      return testDB.getLoan('a loan').should.eventually.be.rejectedWith('No matching record found')
+        .and.should.eventually.be.an.instanceOf(Error)
+    })
+
+    it('should resolve with a loan record if the expiry date is in the future', () => {
+      const getResult = {
+        Item: {
+          loan_id: 'a loan',
+          expiry_date: Math.floor(Date.now() / 1000) + 10
+        }
+      }
+
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
+      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+
+      return testDB.getLoan('a loan').should.eventually.be.fulfilled
+        .and.should.eventually.deep.equal(getResult.Item)
+    })
+
+    it('should be rejected with an error if no matching loan record is found', () => {
+      const getResult = {}
+
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
+      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+
+      return testDB.getLoan('a loan').should.eventually.be.rejectedWith('No matching record found')
+        .and.should.eventually.be.an.instanceOf(Error)
+    })
+
+    it('should be rejected with an error if dynamodb fails', () => {
+      const getStub = sinon.stub()
+      getStub.callsArgWith(1, new Error('DynamoDB broke'), null)
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getStub)
+
+      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+
+      return testDB.getLoan('a loan').should.eventually.be.rejectedWith('DynamoDB broke')
+        .and.should.eventually.be.an.instanceOf(Error)
+    })
+  })
+
+  describe('delete method tests', () => {
+    afterEach(() => {
+      AWS_MOCK.restore('DynamoDB.DocumentClient')
+    })
+
+    it('should call dynamodb delete with the correct params', () => {
+      const deleteStub = sandbox.stub()
+      deleteStub.callsArgWith(1, null, true)
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'delete', deleteStub)
+
+      const params = {
+        Key: {
+          loan_id: 'a loan'
+        },
+        TableName: 'a loan cache table'
+      }
+
+      const testDB = new DB()
+
+      return testDB.delete(params).then(() => {
+        deleteStub.should.have.been.calledWith({
+          Key: {
+            loan_id: 'a loan'
+          },
+          TableName: 'a loan cache table'
+        })
+      })
+    })
+
+    it('should be fulfilled if dynamodb succeeds', () => {
+      const deleteStub = sandbox.stub()
+      deleteStub.callsArgWith(1, null, true)
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'delete', deleteStub)
+
+      const testDB = new DB()
+
+      return testDB.delete('success').should.eventually.be.fulfilled
+    })
+
+    it('should be rejected with an error if dynamodb fails', () => {
+      const deleteStub = sandbox.stub()
+      deleteStub.callsArgWith(1, new Error('DynamoDB error'), null)
+      AWS_MOCK.mock('DynamoDB.DocumentClient', 'delete', deleteStub)
+
+      const testDB = new DB()
+
+      return testDB.delete('error').should.eventually.be.rejectedWith('DynamoDB error')
+    })
+  })
+
+  describe('deleteLoan method tests', () => {
+    it('should call delete with the correct parameters', () => {
+      const deleteStub = sinon.stub(DB.prototype, 'delete')
+      deleteStub.resolves(true)
+
+      const expected = {
+        TableName: 'a cache table',
+        Key: {
+          loan_id: 'a loan'
+        }
+      }
+
+      const testDB = new DB({loanCacheTable: 'a cache table'})
+      return testDB.deleteLoan('a loan').then(() => {
+        deleteStub.should.have.been.calledWith(expected)
+      })
+    })
+  })
+})

--- a/test/db-test.js
+++ b/test/db-test.js
@@ -36,8 +36,8 @@ describe('db class tests', () => {
         TableName: 'UserCacheTable'
       }
 
-      const testDB = new DB()
-      return testDB.save({ user_id: 'a user' }, 'UserCacheTable').then(data => {
+      const testDB = new DB('UserCacheTable')
+      return testDB.save({ user_id: 'a user' }).then(data => {
         putStub.should.be.calledWith(expected)
       })
     })
@@ -47,134 +47,14 @@ describe('db class tests', () => {
       putStub.callsArgWith(1, new Error('DynamoDB put has failed'), null)
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'put', putStub)
 
-      const testDB = new DB()
-      return testDB.save({ user_id: 'a user' }, 'UserCacheTable')
+      const testDB = new DB('UserCacheTable')
+      return testDB.save({ user_id: 'a user' })
         .should.eventually.be.rejectedWith('DynamoDB put has failed')
         .should.eventually.be.an.instanceOf(Error)
     })
   })
 
-  describe('save loan method', () => {
-    it('should call the save method with the input parameters and the loan cache table', () => {
-      const saveStub = sandbox.stub(DB.prototype, 'save')
-      saveStub.resolves(true)
-      const testDB = new DB({ loanCacheTable: 'loan cache table' })
-
-      return testDB.saveLoan('a loan').then(() => {
-        saveStub.should.have.been.calledWith('a loan', 'loan cache table')
-      })
-    })
-  })
-
-  describe('save user method', () => {
-    it('should call the save method with the input parameters and the user cache table', () => {
-      const saveStub = sandbox.stub(DB.prototype, 'save')
-      saveStub.resolves(true)
-      const testDB = new DB({ userCacheTable: 'user cache table' })
-
-      return testDB.saveUser('a user').then(() => {
-        saveStub.should.have.been.calledWith('a user', 'user cache table')
-      })
-    })
-  })
-
-  describe('get user method', () => {
-    afterEach(() => {
-      AWS_MOCK.restore('DynamoDB.DocumentClient')
-    })
-
-    it('should call dynamodb get with the correct parameters', () => {
-      const getStub = sinon.stub()
-
-      const getResult = {
-        Item: {
-          user_id: 'a user'
-        }
-      }
-      getStub.callsArgWith(1, null, getResult)
-      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getStub)
-
-      const expected = {
-        Key: {
-          user_id: 'a user'
-        },
-        TableName: 'UserCacheTable'
-      }
-
-      testDB = new DB({ userCacheTable: 'UserCacheTable' })
-
-      return testDB.getUser('a user').then(data => {
-        getStub.should.be.calledWith(expected)
-      })
-    })
-
-    it('should resolve with a user record if a matching user is found with no expiry date set', () => {
-      const getResult = {
-        Item: {
-          user_id: 'a user'
-        }
-      }
-
-      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      testDB = new DB({ userCacheTable: 'UserCacheTable' })
-
-      return testDB.getUser('a user').should.eventually.be.fulfilled
-        .and.should.eventually.deep.equal({user_id: 'a user'})
-    })
-
-    it('should reject with an error if the user\'s expiry date is in the past', () => {
-      const getResult = {
-        Item: {
-          user_id: 'a user',
-          expiry_date: Math.floor(Date.now() / 1000) - 10
-        }
-      }
-
-      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      testDB = new DB({ userCacheTable: 'UserCacheTable' })
-
-      return testDB.getUser('a user').should.eventually.be.rejectedWith('No matching record found')
-        .and.should.eventually.be.an.instanceOf(Error)
-    })
-
-    it('should resolve with a user record if the expiry date is in the future', () => {
-      const getResult = {
-        Item: {
-          user_id: 'a user',
-          expiry_date: Math.floor(Date.now() / 1000) + 10
-        }
-      }
-
-      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      testDB = new DB({ userCacheTable: 'UserCacheTable' })
-
-      return testDB.getUser('a user').should.eventually.be.fulfilled
-        .and.should.eventually.deep.equal(getResult.Item)
-    })
-
-    it('should be rejected with an error if no matching user record is found', () => {
-      const getResult = {}
-
-      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      testDB = new DB({ userCacheTable: 'UserCacheTable' })
-
-      return testDB.getUser('a user').should.eventually.be.rejectedWith('No matching record found')
-        .and.should.eventually.be.an.instanceOf(Error)
-    })
-
-    it('should be rejected with an error if dynamodb fails', () => {
-      const getStub = sinon.stub()
-      getStub.callsArgWith(1, new Error('DynamoDB broke'), null)
-      AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getStub)
-
-      testDB = new DB({ userCacheTable: 'UserCacheTable' })
-
-      return testDB.getUser('a user').should.eventually.be.rejectedWith('DynamoDB broke')
-        .and.should.eventually.be.an.instanceOf(Error)
-    })
-  })
-
-  describe('get loan method tests', () => {
+  describe('get method tests', () => {
     afterEach(() => {
       AWS_MOCK.restore('DynamoDB.DocumentClient')
     })
@@ -197,9 +77,9 @@ describe('db class tests', () => {
         TableName: 'LoanCacheTable'
       }
 
-      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+      let testDB = new DB('LoanCacheTable')
 
-      return testDB.getLoan('a loan').then(data => {
+      return testDB.get({ loan_id: 'a loan' }).then(data => {
         getStub.should.be.calledWith(expected)
       })
     })
@@ -212,9 +92,9 @@ describe('db class tests', () => {
       }
 
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+      let testDB = new DB('LoanCacheTable')
 
-      return testDB.getLoan('a loan').should.eventually.be.fulfilled
+      return testDB.get({ loan_id: 'a loan' }).should.eventually.be.fulfilled
         .and.should.eventually.deep.equal({loan_id: 'a loan'})
     })
 
@@ -227,9 +107,9 @@ describe('db class tests', () => {
       }
 
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+      let testDB = new DB('LoanCacheTable')
 
-      return testDB.getLoan('a loan').should.eventually.be.rejectedWith('No matching record found')
+      return testDB.get({ loan_id: 'a loan' }).should.eventually.be.rejectedWith('No matching record found')
         .and.should.eventually.be.an.instanceOf(Error)
     })
 
@@ -242,9 +122,9 @@ describe('db class tests', () => {
       }
 
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+      let testDB = new DB('LoanCacheTable')
 
-      return testDB.getLoan('a loan').should.eventually.be.fulfilled
+      return testDB.get({ loan_id: 'a loan' }).should.eventually.be.fulfilled
         .and.should.eventually.deep.equal(getResult.Item)
     })
 
@@ -252,9 +132,9 @@ describe('db class tests', () => {
       const getResult = {}
 
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)
-      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+      let testDB = new DB('LoanCacheTable')
 
-      return testDB.getLoan('a loan').should.eventually.be.rejectedWith('No matching record found')
+      return testDB.get({ loan_id: 'a loan' }).should.eventually.be.rejectedWith('No matching record found')
         .and.should.eventually.be.an.instanceOf(Error)
     })
 
@@ -263,9 +143,9 @@ describe('db class tests', () => {
       getStub.callsArgWith(1, new Error('DynamoDB broke'), null)
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getStub)
 
-      testDB = new DB({ loanCacheTable: 'LoanCacheTable' })
+      let testDB = new DB('LoanCacheTable')
 
-      return testDB.getLoan('a loan').should.eventually.be.rejectedWith('DynamoDB broke')
+      return testDB.get({ loan_id: 'a loan' }).should.eventually.be.rejectedWith('DynamoDB broke')
         .and.should.eventually.be.an.instanceOf(Error)
     })
   })
@@ -280,16 +160,13 @@ describe('db class tests', () => {
       deleteStub.callsArgWith(1, null, true)
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'delete', deleteStub)
 
-      const params = {
-        Key: {
-          loan_id: 'a loan'
-        },
-        TableName: 'a loan cache table'
+      const Key = {
+        loan_id: 'a loan'
       }
 
-      const testDB = new DB()
+      const testDB = new DB('a loan cache table')
 
-      return testDB.delete(params).then(() => {
+      return testDB.delete(Key).then(() => {
         deleteStub.should.have.been.calledWith({
           Key: {
             loan_id: 'a loan'
@@ -317,25 +194,6 @@ describe('db class tests', () => {
       const testDB = new DB()
 
       return testDB.delete('error').should.eventually.be.rejectedWith('DynamoDB error')
-    })
-  })
-
-  describe('deleteLoan method tests', () => {
-    it('should call delete with the correct parameters', () => {
-      const deleteStub = sinon.stub(DB.prototype, 'delete')
-      deleteStub.resolves(true)
-
-      const expected = {
-        TableName: 'a cache table',
-        Key: {
-          loan_id: 'a loan'
-        }
-      }
-
-      const testDB = new DB({loanCacheTable: 'a cache table'})
-      return testDB.deleteLoan('a loan').then(() => {
-        deleteStub.should.have.been.calledWith(expected)
-      })
     })
   })
 })

--- a/test/db-test.js
+++ b/test/db-test.js
@@ -84,7 +84,7 @@ describe('db class tests', () => {
       })
     })
 
-    it('should resolve with a loan record if a matching loan is found with no expiry date set', () => {
+    it('should resolve with a record if a matching one is found with no expiry date set', () => {
       const getResult = {
         Item: {
           loan_id: 'a loan'
@@ -98,7 +98,7 @@ describe('db class tests', () => {
         .and.should.eventually.deep.equal({loan_id: 'a loan'})
     })
 
-    it('should reject with an error if the loan\'s expiry date is in the past', () => {
+    it('should reject with an error if the expiry date is in the past', () => {
       const getResult = {
         Item: {
           loan_id: 'a loan',
@@ -113,7 +113,7 @@ describe('db class tests', () => {
         .and.should.eventually.be.an.instanceOf(Error)
     })
 
-    it('should resolve with a loan record if the expiry date is in the future', () => {
+    it('should resolve with a record if the expiry date is in the future', () => {
       const getResult = {
         Item: {
           loan_id: 'a loan',
@@ -128,7 +128,7 @@ describe('db class tests', () => {
         .and.should.eventually.deep.equal(getResult.Item)
     })
 
-    it('should be rejected with an error if no matching loan record is found', () => {
+    it('should be rejected with an error if no matching record is found', () => {
       const getResult = {}
 
       AWS_MOCK.mock('DynamoDB.DocumentClient', 'get', getResult)

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,7 @@ const Utils = require('../src')
 
 // Test data
 const Topic = require('../src/topic')
+const DB = require('../src/db')
 
 describe('module tests', () => {
   it('should export an object', () => {
@@ -14,5 +15,9 @@ describe('module tests', () => {
 
   it('should export a Topic object matching the one exported by topic.js', () => {
     Utils.Topic.should.deep.equal(Topic)
+  })
+
+  it('should export a DB object matching the one exported by db.js', () => {
+    Utils.DB.should.deep.equal(DB)
   })
 })

--- a/test/timestamp-test.js
+++ b/test/timestamp-test.js
@@ -1,0 +1,22 @@
+const sinon = require('sinon')
+const sandbox = sinon.sandbox.create()
+
+const chai = require('chai')
+chai.should()
+
+// Module under test
+const timestamp = require('../src/timestamp')
+
+describe('timestamp tests', () => {
+  describe('in seconds tests', () => {
+    it('should return a unix timestamp in seconds', () => {
+      const testTime = Date.now()
+      const timeStub = sandbox.stub(Date, 'now')
+      timeStub.returns(testTime)
+
+      const expected = Math.floor(testTime / 1000)
+
+      timestamp.inSeconds().should.equal(expected)
+    })
+  })
+})


### PR DESCRIPTION
This adds a database class wrapper for AWS DynamoDB, to be used to update the Alma cache database.

It adds methods to get, save and delete records. The get method includes a check that retrieved records have not expired.