### PR TITLE
Get queue URL on sendMessage

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -27,14 +27,13 @@ class Queue {
   }
 
   sendMessage (message) {
-    if (this.url) {
-      return this.sqs.sendMessage({
-        MessageBody: message,
-        QueueUrl: this.url
-      }).promise()
-    } else {
-      throw new Error('Queue URL has not been set')
-    }
+    return (this.url ? Promise.resolve() : this.getQueueUrl())
+      .then(() => {
+        return this.sqs.sendMessage({
+          MessageBody: message,
+          QueueUrl: this.url
+        }).promise()
+      })
   }
 }
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -27,7 +27,12 @@ class Queue {
   }
 
   sendMessage (message) {
-    return (this.url ? Promise.resolve() : this.getQueueUrl())
+    return (this.url
+      ? Promise.resolve()
+      : this.getQueueUrl()
+        .catch(e => {
+          throw new Error('Unable to get Queue URL')
+        }))
       .then(() => {
         return this.sqs.sendMessage({
           MessageBody: message,

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -108,11 +108,18 @@ describe('queue class tests', () => {
         .and.should.eventually.equal('message sent')
     })
 
-    it('should throw an error if the Queue URL does not exist', () => {
+    it('should call getQueueUrl if the Queue URL does not exist', () => {
       const testQueue = new Queue('a queue', 'me')
+      const getQueueUrlStub = sandbox.stub(testQueue, 'getQueueUrl')
+      getQueueUrlStub.resolves(true)
+      const sendMessageStub = sandbox.stub(testQueue.sqs, 'sendMessage')
+      sendMessageStub.returns({
+        promise: () => Promise.resolve()
+      })
 
-      expect(() => testQueue.sendMessage('this is a test message')).to.throw(Error)
-      expect(() => testQueue.sendMessage('this is a test message')).to.throw('Queue URL has not been set')
+      return testQueue.sendMessage('this is a test message').then(() => {
+        getQueueUrlStub.should.have.been.calledOnce
+      })
     })
   })
 })

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -121,5 +121,25 @@ describe('queue class tests', () => {
         getQueueUrlStub.should.have.been.calledOnce
       })
     })
+
+    it('should be rejected with a custom error if Queue#getQueueUrl is rejected', () => {
+      const testQueue = new Queue('a queue', 'me')
+      const getQueueUrlStub = sandbox.stub(testQueue, 'getQueueUrl')
+      getQueueUrlStub.rejects(new Error('an error from getQueueURL'))
+
+      return testQueue.sendMessage('this is a test message').should.eventually.be.rejectedWith('Unable to get Queue URL')
+    })
+
+    it('should be rejected with the SQS#sendMessage error if SQS#sendMessage is rejected', () => {
+      const testQueue = new Queue('a queue', 'me')
+      const getQueueUrlStub = sandbox.stub(testQueue, 'getQueueUrl')
+      getQueueUrlStub.resolves(true)
+      const sendMessageStub = sandbox.stub(testQueue.sqs, 'sendMessage')
+      sendMessageStub.returns({
+        promise: () => Promise.reject(new Error('an error from SQS#sendMessage'))
+      })
+
+      return testQueue.sendMessage('this is a test message').should.eventually.be.rejectedWith('an error from SQS#sendMessage')
+    })
   })
 })


### PR DESCRIPTION
Currently `Queue#sendMessage` throws an error if an attempt to send a message is made on a Queue with no URL set.

This changes the method to instead call `getQueueUrl` on the Queue if no URL is set, thereby removing the need to call it separately beforehand.