### PR TITLE
Queue constructor Parameter Object

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -2,9 +2,10 @@ require('aws-sdk/clients/sqs')
 const AWS = require('aws-sdk/global')
 
 class Queue {
-  constructor (name, owner) {
-    this.name = name
-    this.owner = owner
+  constructor (queueParms) {
+    this.name = queueParms.name
+    this.owner = queueParms.owner
+    this.url = queueParms.url
     this.sqs = new AWS.SQS()
   }
 

--- a/test/queue-test.js
+++ b/test/queue-test.js
@@ -29,7 +29,7 @@ describe('queue class tests', () => {
         QueueOwnerAWSAccountId: 'me'
       }
 
-      const testQueue = new Queue('a queue', 'me')
+      const testQueue = new Queue({ name: 'a queue', owner: 'me' })
       return testQueue.getQueueUrl().then(() => {
         urlStub.should.have.been.calledWith(expected)
       })
@@ -38,7 +38,7 @@ describe('queue class tests', () => {
     it('should update the queue object url', () => {
       AWS_MOCK.mock('SQS', 'getQueueUrl', { QueueUrl: 'a url' })
 
-      const testQueue = new Queue('a queue', 'me')
+      const testQueue = new Queue({ name: 'a queue', owner: 'me' })
       return testQueue.getQueueUrl().then(() => {
         testQueue.url.should.equal('a url')
       })
@@ -49,7 +49,7 @@ describe('queue class tests', () => {
       urlStub.callsArgWith(1, new Error('SQS has failed'), null)
       AWS_MOCK.mock('SQS', 'getQueueUrl', urlStub)
 
-      const testQueue = new Queue('a queue', 'an owner')
+      const testQueue = new Queue({ name: 'a queue', owner: 'me' })
       return testQueue.getQueueUrl().should.eventually.be.rejectedWith('SQS has failed')
         .and.should.eventually.be.an.instanceOf(Error)
     })
@@ -59,7 +59,7 @@ describe('queue class tests', () => {
       urlStub.callsArgWith(1, null, { QueueUrl: 'a url' })
       AWS_MOCK.mock('SQS', 'getQueueUrl', urlStub)
 
-      const testQueue = new Queue('a queue', 'an owner')
+      const testQueue = new Queue({ name: 'a queue', owner: 'an owner' })
       return testQueue.getQueueUrl().should.eventually.be.fulfilled
     })
   })
@@ -75,7 +75,7 @@ describe('queue class tests', () => {
         QueueUrl: 'a url'
       }
 
-      const testQueue = new Queue('a queue', 'me')
+      const testQueue = new Queue({ name: 'a queue', owner: 'an owner' })
       testQueue.url = 'a url'
       return testQueue.sendMessage('this is a test message').then(() => {
         sendStub.should.have.been.calledWith(expected)
@@ -87,7 +87,7 @@ describe('queue class tests', () => {
       sendStub.callsArgWith(1, new Error('SQS sendMessage has failed'), null)
       AWS_MOCK.mock('SQS', 'sendMessage', sendStub)
 
-      const testQueue = new Queue('a queue', 'me')
+      const testQueue = new Queue({ name: 'a queue', owner: 'an owner' })
       testQueue.url = 'a url'
 
       return testQueue.sendMessage('this is a test message')
@@ -100,7 +100,7 @@ describe('queue class tests', () => {
       sendStub.callsArgWith(1, null, 'message sent')
       AWS_MOCK.mock('SQS', 'sendMessage', sendStub)
 
-      const testQueue = new Queue('a queue', 'me')
+      const testQueue = new Queue({ name: 'a queue', owner: 'an owner' })
       testQueue.url = 'a url'
 
       return testQueue.sendMessage('this is a test message')
@@ -109,7 +109,7 @@ describe('queue class tests', () => {
     })
 
     it('should call getQueueUrl if the Queue URL does not exist', () => {
-      const testQueue = new Queue('a queue', 'me')
+      const testQueue = new Queue({ name: 'a queue', owner: 'an owner' })
       const getQueueUrlStub = sandbox.stub(testQueue, 'getQueueUrl')
       getQueueUrlStub.resolves(true)
       const sendMessageStub = sandbox.stub(testQueue.sqs, 'sendMessage')
@@ -123,7 +123,7 @@ describe('queue class tests', () => {
     })
 
     it('should be rejected with a custom error if Queue#getQueueUrl is rejected', () => {
-      const testQueue = new Queue('a queue', 'me')
+      const testQueue = new Queue({ name: 'a queue', owner: 'an owner' })
       const getQueueUrlStub = sandbox.stub(testQueue, 'getQueueUrl')
       getQueueUrlStub.rejects(new Error('an error from getQueueURL'))
 
@@ -131,7 +131,7 @@ describe('queue class tests', () => {
     })
 
     it('should be rejected with the SQS#sendMessage error if SQS#sendMessage is rejected', () => {
-      const testQueue = new Queue('a queue', 'me')
+      const testQueue = new Queue({ name: 'a queue', owner: 'an owner' })
       const getQueueUrlStub = sandbox.stub(testQueue, 'getQueueUrl')
       getQueueUrlStub.resolves(true)
       const sendMessageStub = sandbox.stub(testQueue.sqs, 'sendMessage')


### PR DESCRIPTION
This changes the Queue constructor to accept a parameter object instead of individual parameters, and thus adds the option for the Queue to be instantiated with the URL already set.